### PR TITLE
Faster sample import

### DIFF
--- a/ixporter/__init__.py
+++ b/ixporter/__init__.py
@@ -1,1 +1,3 @@
 from .export import Exporter
+
+STATE = {"verbose": False}

--- a/ixporter/__main__.py
+++ b/ixporter/__main__.py
@@ -1,4 +1,4 @@
-from typer import Typer
+from typer import Typer, Argument, Option
 import rich
 from rich import print
 from pathlib import Path
@@ -7,6 +7,7 @@ from pysolr import Solr, SolrError
 
 from ixporter import Exporter
 from ixporter.sample import load_sample_data
+from ixporter.__init__ import STATE
 
 
 app = Typer()
@@ -24,8 +25,19 @@ def import_(database_url: str):
     pass
 
 @app.command()
-def sample(database_url: str, lines: int = 25, timeout: int = 1, threads: int = 150):
+def sample(
+    database_url: str,
+    lines: int = Argument(25),
+    timeout: int = Argument(1),
+    threads: int = Argument(150),
+):
     load_sample_data(Solr(database_url), lines, timeout, threads)
+
+
+@app.callback()
+def main(verbose: bool = Option(False)):
+    if verbose:
+        STATE["verbose"] = True
 
 
 if __name__ == "__main__":

--- a/ixporter/__main__.py
+++ b/ixporter/__main__.py
@@ -24,8 +24,8 @@ def import_(database_url: str):
     pass
 
 @app.command()
-def sample(database_url: str, lines: int = 25):
-    load_sample_data(Solr(database_url), lines)
+def sample(database_url: str, lines: int = 25, timeout: int = 1, threads: int = 150):
+    load_sample_data(Solr(database_url), lines, timeout, threads)
 
 
 if __name__ == "__main__":

--- a/ixporter/__main__.py
+++ b/ixporter/__main__.py
@@ -9,7 +9,6 @@ from ixporter import Exporter
 from ixporter.sample import load_sample_data
 from ixporter.__init__ import STATE
 
-
 app = Typer()
 
 def error(message: str):
@@ -24,12 +23,13 @@ def export(database_url: str, path: Path = Path("./export")):
 def import_(database_url: str):
     pass
 
+
 @app.command()
 def sample(
-    database_url: str,
-    lines: int = Argument(25),
-    timeout: int = Argument(1),
-    threads: int = Argument(150),
+        database_url: str,
+        lines: int = Argument(25),
+        timeout: int = Argument(1),
+        threads: int = Argument(150),
 ):
     load_sample_data(Solr(database_url), lines, timeout, threads)
 

--- a/ixporter/sample.py
+++ b/ixporter/sample.py
@@ -10,6 +10,8 @@ import requests
 from concurrent.futures import ThreadPoolExecutor
 import itertools
 
+from ixporter.__init__ import STATE
+
 
 def _import_url(entry, db, timeout):
     url = entry[3]
@@ -31,14 +33,15 @@ def _import_url(entry, db, timeout):
 
         if len(description) > 150:
             description = description[:149] + "&hellip;"
-    except requests.exceptions.RequestException as e:
-        print(f"Warning: problem connecting to {url}")
-        print(e)
-    except ValueError as e:
-        print(f"Warning: {url} had no content and was ignored")
-        print(e)
+    except requests.exceptions.RequestException:
+        if STATE["verbose"]:
+            print(f"Warning: problem connecting to {url}")
+    except ValueError:
+        if STATE["verbose"]:
+            print(f"Warning: {url} had no content and was ignored")
     else:
-        print(f"Success with {url}")
+        if STATE["verbose"]:
+            print(f"Success with {url}")
         db.add(
             {
                 "url": url,

--- a/ixporter/sample.py
+++ b/ixporter/sample.py
@@ -18,18 +18,16 @@ def _import_url(entry, db, timeout):
     title = entry[4]
 
     try:
-        soup = bs(requests.get(url, timeout=timeout).text, features="html.parser")
+        soup = bs(requests.get(url, timeout=timeout).text,
+                  features="html.parser")
         content = soup.get_text()
         if not content:
             raise ValueError
         description = soup.find("meta", attrs={"name": "description"})
 
         # if there was a description, set that, otherwise just use content
-        description = (
-            description.get("content")
-            if description and description.get("content")
-            else content
-        )
+        description = (description.get("content") if description
+                       and description.get("content") else content)
 
         if len(description) > 150:
             description = description[:149] + "&hellip;"
@@ -42,29 +40,25 @@ def _import_url(entry, db, timeout):
     else:
         if STATE["verbose"]:
             print(f"Success with {url}")
-        db.add(
-            {
-                "url": url,
-                "title": title,
-                "submitter": "sampler",
-                "content": content,
-                "description": description,
-                "votes": 1,
-            }
-        )
+        db.add({
+            "url": url,
+            "title": title,
+            "submitter": "sampler",
+            "content": content,
+            "description": description,
+            "votes": 1,
+        })
 
 
 def load_sample_data(db: Solr, lines: int, timeout: int, threads: int):
     print("Downloading corpus (this should take less than a minute)...")
     corpus_zip = requests.get(
-        "https://www.corpusdata.org/iweb/samples/iweb_sources.zip"
-    )
+        "https://www.corpusdata.org/iweb/samples/iweb_sources.zip")
 
     print("Extracting...")
     with zf.ZipFile(BytesIO(corpus_zip.content)) as unzipper:
-        with open(
-            unzipper.extract("iweb_sources.txt", path="/tmp"), encoding="latin_1"
-        ) as corpus_file:
+        with open(unzipper.extract("iweb_sources.txt", path="/tmp"),
+                  encoding="latin_1") as corpus_file:
             print("Reading...")
 
             if lines == 0:
@@ -76,7 +70,7 @@ def load_sample_data(db: Solr, lines: int, timeout: int, threads: int):
 
             print("Loading entries...")
 
-            list_of_groups = zip(*(iter(reader),) * 1000)
+            list_of_groups = zip(*(iter(reader), ) * 1000)
 
             for batch in list_of_groups:
                 with ThreadPoolExecutor(max_workers=threads) as executor:


### PR DESCRIPTION
This also makes the number of imported samples configurable. Setting a number of 0 imports the whole corpus.

The timeout and thread pool size is configurable.
On my home machine (12c/24t, 32Gb, 1Gib Ethernet) with: 
```
timeout = 1
threads = 600
```
imports a sample of 10_000 links in 

```
Executed in  274.65 secs    fish           external
   usr time   27.73 mins  499.00 micros   27.73 mins
   sys time    0.36 mins   43.00 micros    0.36 mins
```